### PR TITLE
This commit replaces the simple color grid with a more advanced color…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@radix-ui/react-tooltip": "^1.1.8",
         "@tauri-apps/plugin-fs": "^2.4.1",
         "@tauri-apps/plugin-sql": "^2.0.0",
+        "@uiw/react-color": "^2.8.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
@@ -3912,6 +3913,420 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@uiw/color-convert": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/color-convert/-/color-convert-2.8.0.tgz",
+      "integrity": "sha512-eRErVaYCkhtd+lltuGykQSwmxvFU7gTjF3AHHWsTQNa3o+sEBeRNY4urjpvRZRhsV6XgAbwsKe/IAZzuBBLx7g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0"
+      }
+    },
+    "node_modules/@uiw/react-color": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color/-/react-color-2.8.0.tgz",
+      "integrity": "sha512-dAR91k1n2Av67CVMPBzy8rDUnXzNXD2saeg0T5m+lB0zJzjaLHBa1INmHOBNCAQ70JX7mIxp4bjAaNB6pFAMSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-color-alpha": "2.8.0",
+        "@uiw/react-color-block": "2.8.0",
+        "@uiw/react-color-chrome": "2.8.0",
+        "@uiw/react-color-circle": "2.8.0",
+        "@uiw/react-color-colorful": "2.8.0",
+        "@uiw/react-color-compact": "2.8.0",
+        "@uiw/react-color-editable-input": "2.8.0",
+        "@uiw/react-color-editable-input-hsla": "2.8.0",
+        "@uiw/react-color-editable-input-rgba": "2.8.0",
+        "@uiw/react-color-github": "2.8.0",
+        "@uiw/react-color-hue": "2.8.0",
+        "@uiw/react-color-material": "2.8.0",
+        "@uiw/react-color-name": "2.8.0",
+        "@uiw/react-color-saturation": "2.8.0",
+        "@uiw/react-color-shade-slider": "2.8.0",
+        "@uiw/react-color-sketch": "2.8.0",
+        "@uiw/react-color-slider": "2.8.0",
+        "@uiw/react-color-swatch": "2.8.0",
+        "@uiw/react-color-wheel": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-alpha": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-alpha/-/react-color-alpha-2.8.0.tgz",
+      "integrity": "sha512-AZlPF6j+I1XftKt4FZ5VUQ7Au0W1BR/PZvgwKTI+bCb7bbRA2l/2am7aInpvaRAav46o13KneQ06Mgqg4jaDzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-drag-event-interactive": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-block": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-block/-/react-color-block-2.8.0.tgz",
+      "integrity": "sha512-ZIW3W4gKqqsAcBfMZxnKZ82oTbEC0Dr5QUvncADvlck0Xd8UK49BMLjEF16Oy0ensNQ3OlcbbiCt7GqjScyNNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-color-editable-input": "2.8.0",
+        "@uiw/react-color-swatch": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-chrome": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-chrome/-/react-color-chrome-2.8.0.tgz",
+      "integrity": "sha512-CM9GIjdMaAuNVbku7Jd/5ekrVYEFt1ZzfFBMIwgDWHWhfUoCKIL+Bet1uztA+CNhpIRmNzb6/gH+3WBJjBG9Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-color-alpha": "2.8.0",
+        "@uiw/react-color-editable-input": "2.8.0",
+        "@uiw/react-color-editable-input-hsla": "2.8.0",
+        "@uiw/react-color-editable-input-rgba": "2.8.0",
+        "@uiw/react-color-github": "2.8.0",
+        "@uiw/react-color-hue": "2.8.0",
+        "@uiw/react-color-saturation": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-circle": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-circle/-/react-color-circle-2.8.0.tgz",
+      "integrity": "sha512-pPt4+33OwhDv7m5NDrYMTxiCpbqweZ0MmmvcYx8neA6Yh/zoKUKk4QtQeFkbiPtbN3QMOahkYIbxtPi6egc63w==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-color-swatch": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-colorful": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-colorful/-/react-color-colorful-2.8.0.tgz",
+      "integrity": "sha512-m6FdmmQgiYEouBr59MFCrCPR34uhR5h0G3koRa64wBH6nHFyzK2wk3fXSgjc3Ckxmol34h7cbMtQwvU1+JiqBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-color-alpha": "2.8.0",
+        "@uiw/react-color-hue": "2.8.0",
+        "@uiw/react-color-saturation": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-compact": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-compact/-/react-color-compact-2.8.0.tgz",
+      "integrity": "sha512-SOiLf+/MQqZ23gJwIkTklpOWUbl3cTy0vqPvfAIo5wcdbLRdczc0ngJnpE7BIj/SmdqrWKeEPksZGReICtXuwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-color-editable-input": "2.8.0",
+        "@uiw/react-color-editable-input-rgba": "2.8.0",
+        "@uiw/react-color-swatch": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-editable-input": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-editable-input/-/react-color-editable-input-2.8.0.tgz",
+      "integrity": "sha512-wChSbI57NLOmJNzMBlQdwAQPi1CzERImEmK0gsczu7AlV/Zt9i5AdN0a1h5lPtIck5KRSiGUlbNK3e5AnVgRsg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-editable-input-hsla": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-editable-input-hsla/-/react-color-editable-input-hsla-2.8.0.tgz",
+      "integrity": "sha512-X1S9CXhYx5To3WhE7Y7Jwwx9AyHZ9UqlX2vtGyIzQ9ayHgepOBLfmel9OWpWU4IZcHMjgD6M0SZC4k9WkMnvjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-color-editable-input-rgba": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-editable-input-rgba": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-editable-input-rgba/-/react-color-editable-input-rgba-2.8.0.tgz",
+      "integrity": "sha512-Y0SWSU0hApJs4TvklTx+x+1y8e/gvNAtfsedzTfspk2pMjF3kPS5B/8tE+jowkBdTXEwQhziihK0LUWY19RydA==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-color-editable-input": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-github": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-github/-/react-color-github-2.8.0.tgz",
+      "integrity": "sha512-6l0kuPY6UmJmDKYmomabror/LnIxy6kVoTXyoK9HJEEa8PijKGET5ma1fHbV1bjhD5bTW7LTjFfrTROCc3ttgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-color-swatch": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-hue": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-hue/-/react-color-hue-2.8.0.tgz",
+      "integrity": "sha512-4/oCVaD9gsqnqfjM2LMiyVx1YbM6l9G+HqrOZRBuBqL+UirLmNLSLZTMbhbezzvjxu+5cJMzt8ezT+jxkRqBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-color-alpha": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-material": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-material/-/react-color-material-2.8.0.tgz",
+      "integrity": "sha512-Q4d37XAw+0s93dRPpeaiSBOANC4zBuofLns7FRiiepwTQXeUqQlkKv9SbFlnYZ117k6aUxaxWhbjpN6m8/nLFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-color-editable-input": "2.8.0",
+        "@uiw/react-color-editable-input-rgba": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-name": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-name/-/react-color-name-2.8.0.tgz",
+      "integrity": "sha512-JEhiLf3vhvm1XhGBfysRAEcW8REVLofd/sY91COZJWpeGkX77V68qzBpqbnqfb7Zd2SCmEGr4+vCHWu5PJ3EyA==",
+      "license": "MIT",
+      "dependencies": {
+        "colors-named": "^1.0.1",
+        "colors-named-hex": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0"
+      }
+    },
+    "node_modules/@uiw/react-color-saturation": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-saturation/-/react-color-saturation-2.8.0.tgz",
+      "integrity": "sha512-zpo7P+93Nu2VoBj9Mo3Ipn3ppjEl5SkdM/UDfn3PVdup9K67T451iyLMTgyUvHOegW9rBhyS7X1j68PmX/xd0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-drag-event-interactive": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-shade-slider": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-shade-slider/-/react-color-shade-slider-2.8.0.tgz",
+      "integrity": "sha512-JmALqFX93qVAYEzycqUvwMBpzCZJF8olVkD7XzHLs09UT7AsQP1usk3oAhzTNQi56Qo3NuqUvvdemHYGdj60jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-color-alpha": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-sketch": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-sketch/-/react-color-sketch-2.8.0.tgz",
+      "integrity": "sha512-qLRRmDKhdFrRil4xYBum31SRdWbdh1F5diP0PbCB8XdP5O0fBVuV5g2EvEvCqoiMecYhMwVicmZIrzhrmyjr+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-color-alpha": "2.8.0",
+        "@uiw/react-color-editable-input": "2.8.0",
+        "@uiw/react-color-editable-input-rgba": "2.8.0",
+        "@uiw/react-color-hue": "2.8.0",
+        "@uiw/react-color-saturation": "2.8.0",
+        "@uiw/react-color-swatch": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-slider": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-slider/-/react-color-slider-2.8.0.tgz",
+      "integrity": "sha512-NIvDlsTAywmgID7ozUzCoKZAWWfd5AYeK6Qu0RNH5GIg3Eh4es3saGce7mOlHVh9+Unn8/O/F6QT172reRxU3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-color-alpha": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-swatch": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-swatch/-/react-color-swatch-2.8.0.tgz",
+      "integrity": "sha512-88X9iSQEqTu609BcGnbgc2Oeq+/UHPv6uL1lGGPMVxjKm9WO7z8PlizmkWSGaLL1ELHEKMfufFbFQ4BJktuWrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-wheel": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-wheel/-/react-color-wheel-2.8.0.tgz",
+      "integrity": "sha512-yajL/ckt9xopU1nf/Z5Fpw6iMuuW7knF3FCh/dCPsuzPB+lrqPi9zZmrgRnbl6H2pMYtXG/KqH5DDeryIDXfpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.8.0",
+        "@uiw/react-drag-event-interactive": "2.8.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-drag-event-interactive": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@uiw/react-drag-event-interactive/-/react-drag-event-interactive-2.8.0.tgz",
+      "integrity": "sha512-BE9eakoBxGtIk267weYvFm13NrGa+4k/6Iv5e3XxW6gToCGVc4QODQBoRFSNpR28W7JIekgqVjlNyvBUAmRwMg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
@@ -4800,6 +5215,30 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/colors-named": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/colors-named/-/colors-named-1.0.2.tgz",
+      "integrity": "sha512-2ANq2r393PV9njYUD66UdfBcxR1slMqRA3QRTWgCx49JoCJ+kOhyfbQYxKJbPZQIhZUcNjVOs5AlyY1WwXec3w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/colors-named-hex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/colors-named-hex/-/colors-named-hex-1.0.2.tgz",
+      "integrity": "sha512-k6kq1e1pUCQvSVwIaGFq2l0LrkAPQZWyeuZn1Z8nOiYSEZiKoFj4qx690h2Kd34DFl9Me0gKS6MUwAMBJj8nuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
       }
     },
     "node_modules/concat-map": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-tooltip": "^1.1.8",
     "@tauri-apps/plugin-fs": "^2.4.1",
     "@tauri-apps/plugin-sql": "^2.0.0",
+    "@uiw/react-color": "^2.8.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -52,7 +52,7 @@ import {
 } from "@/components/ui/collapsible";
 import { ScrollArea } from "./ui/scroll-area";
 import { cn } from "@/lib/utils";
-import { ColorPicker, COLORS } from "./ui/color-picker";
+import { ColorPicker } from "./ui/color-picker";
 
 interface AppSidebarProps {
   projects: Project[];
@@ -83,7 +83,7 @@ export function AppSidebar({
 }: AppSidebarProps) {
   // Add Project State
   const [newProjectName, setNewProjectName] = React.useState("");
-  const [newProjectColor, setNewProjectColor] = React.useState(COLORS[0]);
+  const [newProjectColor, setNewProjectColor] = React.useState("#ef4444");
   const [isAddProjectDialogOpen, setIsAddProjectDialogOpen] = React.useState(false);
 
   // Edit Project State
@@ -101,7 +101,7 @@ export function AppSidebar({
     if (newProjectName.trim()) {
       onAddProject({ name: newProjectName.trim(), color: newProjectColor });
       setNewProjectName("");
-      setNewProjectColor(COLORS[0]);
+      setNewProjectColor("#ef4444");
       setIsAddProjectDialogOpen(false);
     }
   };

--- a/src/components/ui/color-picker.tsx
+++ b/src/components/ui/color-picker.tsx
@@ -2,12 +2,9 @@
 
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { Check } from "lucide-react";
-
-export const COLORS = [
-  "#ef4444", "#f97316", "#eab308", "#84cc16", "#22c55e", "#14b8a6",
-  "#0ea5e9", "#3b82f6", "#8b5cf6", "#d946ef", "#ec4899", "#78716c"
-];
+import { Paintbrush } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Sketch } from "@uiw/react-color";
 
 interface ColorPickerProps {
   value: string;
@@ -17,22 +14,29 @@ interface ColorPickerProps {
 
 export function ColorPicker({ value, onChange, className }: ColorPickerProps) {
   return (
-    <div className={cn("grid grid-cols-6 gap-2", className)}>
-      {COLORS.map((color) => (
+    <Popover>
+      <PopoverTrigger asChild>
         <button
-          key={color}
           type="button"
           className={cn(
             "h-8 w-8 rounded-full border flex items-center justify-center transition-transform transform hover:scale-110",
-            value === color && "ring-2 ring-ring ring-offset-2 ring-offset-background"
+            className
           )}
-          style={{ backgroundColor: color }}
-          onClick={() => onChange(color)}
-          aria-label={`Select color ${color}`}
+          style={{ backgroundColor: value }}
+          aria-label="Select color"
         >
-          {value === color && <Check className="h-5 w-5 text-white mix-blend-difference" />}
+          <Paintbrush className="h-5 w-5 text-white mix-blend-difference" />
         </button>
-      ))}
-    </div>
+      </PopoverTrigger>
+      <PopoverContent className="p-0">
+        <Sketch
+          style={{ marginLeft: 20 }}
+          color={value}
+          onChange={(color) => {
+            onChange(color.hex);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
   );
 }


### PR DESCRIPTION
… picker, similar to the one in Photoshop.

Key changes:
- Added the `@uiw/react-color` dependency to provide the new color picker component.
- Modified `src/components/ui/color-picker.tsx` to use the `<Sketch />` component from `@uiw/react-color` inside a popover.
- Updated `src/components/app-sidebar.tsx` to work with the new color picker, including setting a default color and handling state updates.
- Created a Playwright script to visually verify the new color picker functionality.

I was unable to add a permanent Playwright test to the repository as requested. I was stuck debugging the application after my initial changes, which prevented me from completing the test implementation. The application was returning a 500 error, and I was in the process of debugging it when I was asked to hand things over. The current changes implement the new color picker, but without a permanent test.